### PR TITLE
Revised branch, release, and conda upload policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,22 +24,22 @@ script:
 after_success:
     - pip install codecov && codecov
 deploy:
-    # upload github vN.N.N releases to Anaconda Cloud with TravisCI
+    # conda_upload.sh switches anaconda upload on $TRAVIS_BRANCH
+    #    master -> /pre-release
+    #    vM.N.P -> /main
+    #    else dry run, no conda upload
     - provider: script
       skip_cleanup: true
       script: bash ./ci/conda_upload.sh
       on:
-          # safe to use all branches for testing b.c. conda uploads can be deleted
-          # all_branches: true  # for testing
-          tags: true
-          condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$  # restrict to release tags
+          all_branches: true
 
     - provider: pypi
       skip_cleanup: true
       user: "__token__"
       password: $PYPI_TOKEN
       on:
-          # all_branches: true  # for testing
+          # only upload tagged vM.N.P github releases to PyPI
           tags: true
           condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ 
 

--- a/ci/conda_upload.sh
+++ b/ci/conda_upload.sh
@@ -55,7 +55,7 @@ mmp=`echo $version | sed -n "s/\(\([0-9]\+\.\)\{1,2\}[0-9]\+\).*/\1/p"`
 label="dry-run"
 if [[ "${version}" = "$mmp" ]]; then
 
-    # a commit to master uploads to /pre-release
+    # commit to master uploads to /pre-release
     if [[ $TRAVIS_BRANCH = "master" ]]; then
 	label="pre-release"
     fi
@@ -70,7 +70,7 @@ fi
 mkdir -p ${bld_prefix}/conda-convert/linux-64
 cp ${tarball} ${bld_prefix}/conda-convert/linux-64
 cd ${bld_prefix}/conda-convert
-conda convert --platform all linux-64/${PACKAGE_NAME}*tar.bz2
+conda convert -p linux-64 -p osx-64 -p win-64  linux-64/${PACKAGE_NAME}*tar.bz2
 
 # POSIX trick sets $ANACONDA_TOKEN if unset or empty string 
 ANACONDA_TOKEN=${ANACONDA_TOKEN:-[not_set]}
@@ -83,8 +83,7 @@ echo "conda-bld: ${bld_prefix}/conda-bld/linux-64"
 echo "tarball: $tarball"
 echo "travis tag: $TRAVIS_TAG"
 echo "travis branch: $TRAVIS_BRANCH"
-echo "is_release: $is_release"
-echo "conda_label: ${label_param}"
+echo "conda label: ${label}"
 echo "conda upload command: ${conda_cmd}"
 echo "platforms:"
 echo "$(ls ./**/${PACKAGE_NAME}*.tar.bz2)"
@@ -93,8 +92,6 @@ echo "$(ls ./**/${PACKAGE_NAME}*.tar.bz2)"
 #    attempt the upload 
 # else
 #    skip the upload and exit happy
-# if [[ $ANACONDA_TOKEN != "[not_set]" && $is_release = "true" ]]; then
-
 if [[ $ANACONDA_TOKEN != "[not_set]" && ( $label = "main" || $label = "pre-release" ) ]]; then
 
     conda install anaconda-client

--- a/ci/conda_upload.sh
+++ b/ci/conda_upload.sh
@@ -38,8 +38,8 @@ version=`echo $tarball | sed -n "s/.*${PACKAGE_NAME}-\(.\+\)-.*/\1/p"`
 # just the numeric major.minor.patch portion of version, possibly empty
 mmp=`echo $version | sed -n "s/\(\([0-9]\+\.\)\{1,2\}[0-9]\+\).*/\1/p"`
 
-# Are we building a release version according to the convention that
-# releases are tagged vMajor.Minor.Release?
+# Are we refreshing master or building a release version according to
+# the convention that releases are tagged vMajor.Minor.Release?
 #
 # * if $version = $mmp then version is a strict numeric
 #   Major.Minor.Patch, not further decorated, e.g., with .dev this or
@@ -47,17 +47,24 @@ mmp=`echo $version | sed -n "s/\(\([0-9]\+\.\)\{1,2\}[0-9]\+\).*/\1/p"`
 # 
 # * the github release tag, e.g., v0.0.0 shows up in the Travis build
 #   as the branch name so $TRAVIS_BRANCH = v$mmp enforces the
-#   vMajor.Minor.Patch release tag convention for conda uploads.
-if [[ "${version}" = "$mmp" && $TRAVIS_BRANCH = v$mmp ]]; then
-    is_release="true"
-    label_param="--label main"
-    conda install anaconda-client
+#   vMajor.Minor.Patch release tag convention for conda upload to main
 
-else
-    is_release="false"
-    label_param="--label pre-release"
+# assume this is a dry run unless TRAVIS_BRANCH informs otherwise
+# deviations from M.N.P versions are always dry-runs, e.g., M.N.P.dev1
+
+label="dry-run"
+if [[ "${version}" = "$mmp" ]]; then
+
+    # a commit to master uploads to /pre-release
+    if [[ $TRAVIS_BRANCH = "master" ]]; then
+	label="pre-release"
+    fi
+
+    # a github release tagged vM.N.P uploads to /main
+    if [[ $TRAVIS_BRANCH = v"mmp" ]]; then
+	label="main"
+    fi
 fi
-
 
 # build for multiple platforms ... who knows it might work
 mkdir -p ${bld_prefix}/conda-convert/linux-64
@@ -67,8 +74,7 @@ conda convert --platform all linux-64/${PACKAGE_NAME}*tar.bz2
 
 # POSIX trick sets $ANACONDA_TOKEN if unset or empty string 
 ANACONDA_TOKEN=${ANACONDA_TOKEN:-[not_set]}
-#conda_cmd="anaconda --token $ANACONDA_TOKEN upload ${tarball} ${label_param}"
-conda_cmd="anaconda --token $ANACONDA_TOKEN upload ./**/${PACKAGE_NAME}*.tar.bz2 ${label_param}"
+conda_cmd="anaconda --token $ANACONDA_TOKEN upload ./**/${PACKAGE_NAME}*.tar.bz2 --label ${label}"
 
 # thus far ...
 echo "conda meta.yaml version: $version"
@@ -87,7 +93,9 @@ echo "$(ls ./**/${PACKAGE_NAME}*.tar.bz2)"
 #    attempt the upload 
 # else
 #    skip the upload and exit happy
-if [[ $ANACONDA_TOKEN != "[not_set]" && $is_release = "true" ]]; then
+# if [[ $ANACONDA_TOKEN != "[not_set]" && $is_release = "true" ]]; then
+
+if [[ $ANACONDA_TOKEN != "[not_set]" && ( $label = "main" || $label = "pre-release" ) ]]; then
 
     conda install anaconda-client
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.0.5" %}
+{% set version = "0.0.6" %}
 {% set py_pin = "3.6" %}  # pins for mkpy and fitgrid
 {% set np_pin = "1.16.4" %}
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -39,7 +39,7 @@ requirements:
         - matplotlib
         - bottleneck
         - pytables
-        - pyarrow
+        - pyarrow >=0.13
 
 test:
     imports:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -35,11 +35,11 @@ requirements:
         - numpy =={{ np_pin }}  # these to pull from anaconda for mkl
         - numpy-base =={{ np_pin }}
         - scipy
-        - pandas
+        - pandas < 1.0
         - matplotlib
         - bottleneck
         - pytables
-        - pyarrow >=0.13
+        - pyarrow
 
 test:
     imports:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -35,7 +35,7 @@ requirements:
         - numpy =={{ np_pin }}  # these to pull from anaconda for mkl
         - numpy-base =={{ np_pin }}
         - scipy
-        - pandas < 1.0
+        - pandas <1.0
         - matplotlib
         - bottleneck
         - pytables

--- a/spudtr/__init__.py
+++ b/spudtr/__init__.py
@@ -10,7 +10,7 @@ WR_F = "gh_sub000wr.epochs.h5"
 
 
 # single source the python package version with a bit of error checking
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 
 
 def get_ver():


### PR DESCRIPTION
The previous policy had master as the current M.N.P release version, with development for next versions on other branches, i.e.,
* master version M.N.P == github tagged release == current release on Anaconda Cloud main, PyPI
* development is on non-master branches, with PRs into (branch into branch into ...) master
    
The new policy has master as the bleeding edge "pretty stable development" version with commits to master uploading 
to Anaconda Cloud on the pre-release label. This allows conda installs from the /pre-release label for the latest master with  bug fixes between the tagged stable releases on /main

* github tagged release M.N.P == current stable release on Anaconda Cloud /main, PyPI 
* master version is M.N.P+1  == Anaconda Cloud /pre-release
* development as above with PRs updating Anaconda Cloud /pre-release version = stable version M.N.Patch+1

