### PR TITLE
replace conda's GIT_BUILD_STR with manual GIT_ABBREV_COMMIT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ env:
     - PACKAGE_NAME: spudtr   # for the conda_upload.sh deploy script
 language: minimal
 before_install:
+    # b.c conda build GIT_BUILD_STR works (or not) in mysterious ways ...
+    # pfx g means ordinary commit, r means github tagged vM.N.P release
+    - if [[ $TRAVIS_TAG =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then pfx=r; else pfx=g; fi
+    - export GIT_ABBREV_COMMIT=${pfx}$(git log --full-history --abbrev-commit --oneline -n 1 | awk '{print $1}')
+    - echo "git commit $GIT_ABBREV_COMMIT"
     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda
     - source $HOME/miniconda/etc/profile.d/conda.sh && conda activate

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,5 @@ deploy:
       script: bash ./ci/ghpages_upload.sh
       on:
           # branch: master
-          all_branches: true   # testing only
-          # tags: true
-          # condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$  # restrict to release tags
+          all_branches: master
+

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.0.6" %}
+{% set version = "0.0.7" %}
 {% set py_pin = "3.6" %}  # pins for mkpy and fitgrid
 {% set np_pin = "1.16.4" %}
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,7 +18,7 @@ source:
 
 build:
     script: python setup.py install --single-version-externally-managed --record=record.txt
-    string: {{ environ.get("GIT_BUILD_STR", "no_git_build_str") }}_{{ environ.get("PKG_BUILDNUM", "no_pkg_buildnum") }}
+    string: {{ environ.get("GIT_ABBREV_COMMIT", "no_git_abbrev_commit") }}_{{ environ.get("PKG_BUILDNUM", "no_pkg_buildnum") }}
 
 requirements:
     # build ... all moved to host

--- a/spudtr/__init__.py
+++ b/spudtr/__init__.py
@@ -10,7 +10,7 @@ WR_F = "gh_sub000wr.epochs.h5"
 
 
 # single source the python package version with a bit of error checking
-__version__ = "0.0.6"
+__version__ = "0.0.7"
 
 
 def get_ver():


### PR DESCRIPTION
* Deployment. .travis.yml scrapes the short git hash into an environment variable GIT_ABBREV_COMMIT.
Routine commits to master are prefixed "g", tagged v.M.N.P releases are prefixed "r". The conda build includes GIT_ABBREV_COMMIT in the package tarball filename for upload to Anaconda Cloud.

* Docs now deploy on master branch commits.

* Version bump to 0.0.7