### PR TITLE
center_eeg updated to return epochs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,5 @@ deploy:
       skip_cleanup: true
       script: bash ./ci/ghpages_upload.sh
       on:
-          # branch: master
-          all_branches: master
+          branch: master
 


### PR DESCRIPTION
The previous release with faster centering, transformed epochs_df in place. This is a breaking change, and  different from the other epf transforms which return copies. This patch restores previous behavior which aligns with the other transforms.

Some test_epf.py tests were stiffened by adding epf._epochs_QC to the end of the user API function tests.