### PR TITLE
master version bump 0.0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,14 @@ script:
 after_success:
     - pip install codecov && codecov
 deploy:
+
+    # homegrown replacement for pages provider
+    - provider: script
+      skip_cleanup: true
+      script: bash ./ci/ghpages_upload.sh
+      on:
+          branch: master
+
     # conda_upload.sh switches anaconda upload on $TRAVIS_BRANCH
     #    master -> /pre-release
     #    vM.N.P -> /main
@@ -48,10 +56,4 @@ deploy:
           tags: true
           condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ 
 
-    # homegrown replacement for pages provider
-    - provider: script
-      skip_cleanup: true
-      script: bash ./ci/ghpages_upload.sh
-      on:
-          branch: master
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.0.8" %}
+{% set version = "0.0.9" %}
 {% set py_pin = "3.6" %}  # pins for mkpy and fitgrid
 {% set np_pin = "1.16.4" %}
 

--- a/spudtr/__init__.py
+++ b/spudtr/__init__.py
@@ -10,7 +10,7 @@ WR_F = "gh_sub000wr.epochs.h5"
 
 
 # single source the python package version with a bit of error checking
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 
 
 def get_ver():


### PR DESCRIPTION
And re-ordered TraviCI deploy to make PyPI last.