### PR TITLE
update CI for py36 py37 py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,61 +1,86 @@
 # spudtr requires a current GIT_TOKEN on TravisCI kutaslab/spudtr
 env:
+  global:
     - PACKAGE_NAME: spudtr   # for the conda_upload.sh deploy script
+
 language: minimal
+
+jobs:
+  include:
+    - name: "3.6 build"
+      env: PYV=3.6
+    - name: "3.7 build"
+      env: PYV=3.7
+    - name: "3.8 build"
+      env: PYV=3.8
+    - name: "default python build"
+      env: PYV=""
+
 before_install:
-    # b.c conda build GIT_BUILD_STR works (or not) in mysterious ways ...
-    # pfx g means ordinary commit, r means github tagged vM.N.P release
-    - if [[ $TRAVIS_TAG =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then pfx=r; else pfx=g; fi
-    - export GIT_ABBREV_COMMIT=${pfx}$(git log --full-history --abbrev-commit --oneline -n 1 | awk '{print $1}')
-    - echo "git commit $GIT_ABBREV_COMMIT"
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - source $HOME/miniconda/etc/profile.d/conda.sh && conda activate
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda info -a
+  # b.c conda build GIT_BUILD_STR works (or not) in mysterious ways ...
+  # pfx g means ordinary commit, r means github tagged vM.N.P release
+  - if [[ $TRAVIS_TAG =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then pfx=r; else pfx=g; fi
+  - export GIT_ABBREV_COMMIT=${pfx}$(git log --full-history --abbrev-commit --oneline -n 1 | awk '{print $1}')
+  - echo "git commit $GIT_ABBREV_COMMIT"
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - source $HOME/miniconda/etc/profile.d/conda.sh && conda activate
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda info -a
+
 install:
-    - conda install -q conda-build conda-verify
-    - conda build conda -c defaults -c conda-forge
-    - conda create --name spudtr_env spudtr -c local -c defaults -c conda-forge
-    - conda activate spudtr_env  # so tests run in env as installed by conda
-    - conda install black pytest-cov
-    - conda list
-    - lscpu
-    - python -c 'import numpy; numpy.show_config()'
+  - conda install -q conda-build conda-verify
+  - conda build --python=${PYV} -c defaults -c conda-forge conda
+
 script:
-    - black --check --verbose .
-    - pytest --cov=spudtr
+  # install and test py 3.x variants
+  - conda create -n pyenv_${PYV} python=${PYV} spudtr -c local -c defaults -c conda-forge
+  - conda activate pyenv_${PYV}
+  - conda install black pytest pytest-cov
+  - conda list
+  - lscpu
+  - python -c 'import numpy; numpy.show_config()'
+  - black --check --verbose .
+  - pytest --cov=spudtr
+
 after_success:
-    - pip install codecov && codecov
+
 deploy:
 
-    # homegrown replacement for pages provider
-    - provider: script
-      skip_cleanup: true
-      script: bash ./ci/ghpages_upload.sh
-      on:
-          branch: master   # for normal operation
-          # all_branches: true  # for testing deploy only
+  - provider: script
+    skip_cleanup: true
+    script: pip install codecov && codecov
+    on:
+      branch: master
+      condition: $PYV == "3.8"
 
-    # conda_upload.sh switches anaconda upload on $TRAVIS_BRANCH
-    #    master M.N.P or M.N.P.devX -> /pre-release
-    #    tagged vM.N.P -> /main
-    #    else dry run, no conda upload
-    - provider: script
-      skip_cleanup: true
-      script: bash ./ci/conda_upload.sh
-      on:
-          all_branches: true
+  # homegrown replacement for pages provider
+  - provider: script
+    skip_cleanup: true
+    script: bash ./ci/ghpages_upload.sh
+    on:
+      # branch: master   # for normal operation
+      condition: $PYV == "3.8"
+      all_branches: true  # for testing deploy only
 
-    - provider: pypi
-      skip_cleanup: true
-      user: "__token__"
-      password: $PYPI_TOKEN
-      on:
-          # only upload tagged vM.N.P github releases to PyPI
-          branch: master
-          tags: true
-          condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ 
+  # conda_upload.sh switches anaconda upload on $TRAVIS_BRANCH
+  #    master M.N.P or M.N.P.devX -> /pre-release
+  #    tagged vM.N.P -> /main
+  #    else dry run, no conda upload
+  - provider: script
+    skip_cleanup: true
+    script: bash ./ci/conda_upload.sh
+    on:
+      all_branches: true
+      condition: $PYV == "3.8"
 
-
+  - provider: pypi
+    skip_cleanup: true
+    user: "__token__"
+    password: $PYPI_TOKEN
+    on:
+      # only upload tagged vM.N.P github releases to PyPI
+      branch: master
+      tags: true
+      condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && $PYV == "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,9 @@ deploy:
     skip_cleanup: true
     script: bash ./ci/ghpages_upload.sh
     on:
-      # branch: master   # for normal operation
+      branch: master   # for normal operation
       condition: $PYV == "3.8"
-      all_branches: true  # for testing deploy only
+      # all_branches: true  # for testing deploy only
 
   # conda_upload.sh switches anaconda upload on $TRAVIS_BRANCH
   #    master M.N.P or M.N.P.devX -> /pre-release

--- a/ci/conda_upload.sh
+++ b/ci/conda_upload.sh
@@ -58,7 +58,7 @@ label="dry-run"
 if [[ "${version}" =~ ^${mmp}(.dev[0-9]+){0,1}$ ]]; then
 
     # commit to master uploads to /pre-release
-    if [[ $TRAVIS_BRANCH = "master" ]]; then
+    if [[ $TRAVIS_BRANCH = "dev" ]]; then
 	label="pre-release"
     fi
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,3 +1,5 @@
+{% set data = load_setup_py_data() %}
+
 # deprecated {% set version = "0.0.10.dev1" %} 
 # deprecated {% set py_pin = "3.6" %}  # old pins for mkpy and fitgrid
 # deprecated {% set np_pin = "1.16.4" %}

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,10 +1,10 @@
-{% set version = "0.0.10.dev1" %}
-# {% set py_pin = "3.6" %}  # pins for mkpy and fitgrid
-# {% set np_pin = "1.16.4" %}
+# deprecated {% set version = "0.0.10.dev1" %} 
+# deprecated {% set py_pin = "3.6" %}  # old pins for mkpy and fitgrid
+# deprecated {% set np_pin = "1.16.4" %}
 
 package:
   name: spudtr
-  version: {{ version }}
+  version: {{ data.get('version') }}
 
 source:
   # path: ../
@@ -18,18 +18,15 @@ requirements:
   # build ... all moved to host
   host:
     - python {{ python }}
-    - pandas >=1.0
-    - pyarrow >=1.0
-    - requests 
     - pip
 
   run:
     - python {{ python }}
-    - numpy 
+    - numpy
     - numpy-base
     - scipy
     - pandas >=1.0
-    - pyarrow >=1.0  # else defaults to 0.11.1 which crashes
+    - pyarrow >=1.0
     - matplotlib
     - bottleneck
     - pytables

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -3,43 +3,45 @@
 # {% set np_pin = "1.16.4" %}
 
 package:
-    name: spudtr
-    version: {{ version }}
+  name: spudtr
+  version: {{ version }}
 
 source:
-    # path: ../
-    git_url: ../  # to enable GIT_X_Y env vars
+  # path: ../
+  git_url: ../  # to enable GIT_X_Y env vars
 
 build:
-    script: python setup.py install --single-version-externally-managed --record=record.txt
-    string: {{ environ.get("GIT_ABBREV_COMMIT", "no_git_abbrev_commit") }}_{{ environ.get("PKG_BUILDNUM", "no_pkg_buildnum") }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  string: py{{environ.get("CONDA_PY", "XX")}}{{environ.get("GIT_ABBREV_COMMIT", "no_git_abbrev_commit") }}_{{ environ.get("PKG_BUILDNUM", "no_pkg_buildnum") }}
 
 requirements:
-    # build ... all moved to host
-    host:
-      - python
-      - numpy
-      - pip
+  # build ... all moved to host
+  host:
+    - python {{ python }}
+    - pandas >=1.0
+    - pyarrow >=1.0
+    - requests 
+    - pip
 
-    run:
-      - python 
-      - numpy 
-      - numpy-base
-      - scipy
-      - pandas >=1.0
-      - pyarrow >=1.0  # else defaults to 0.11.1 which crashes
-      - matplotlib
-      - bottleneck
-      - pytables
-      - patsy
-      - requests
-      - mne >=0.20.0
+  run:
+    - python {{ python }}
+    - numpy 
+    - numpy-base
+    - scipy
+    - pandas >=1.0
+    - pyarrow >=1.0  # else defaults to 0.11.1 which crashes
+    - matplotlib
+    - bottleneck
+    - pytables
+    - patsy
+    - requests
+    - mne >=0.20.0
 
 test:
-    imports:
-        - spudtr
+  imports:
+    - spudtr
 
 about:
-    home: https://github.com/kutaslab/spudtr
-    license: BSD
-    license_file: LICENSE
+  home: https://github.com/kutaslab/spudtr
+  license: BSD
+  license_file: LICENSE

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -142,7 +142,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "spudtr.tex", "spudtr Documentation", "Thomas P. Urbach", "manual",)
+    (master_doc, "spudtr.tex", "spudtr Documentation", "Thomas P. Urbach", "manual")
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,17 +7,6 @@ from spudtr import get_ver
 
 __version__ = get_ver()
 
-# enforce conda meta.yaml and __init__.py version are the same
-jinja_version = f'{{% set version = "{__version__}" %}}'
-meta_yaml_f = Path("./conda/meta.yaml")
-with open(meta_yaml_f) as f:
-    if not re.match(r"^" + jinja_version, f.read()):
-        fail_msg = (
-            "conda/meta.yaml must start with a jinja variable line exactly like this: "
-            f"{jinja_version}"
-        )
-        raise Exception(fail_msg)
-
 with open("README.md", "r") as fh:
     long_description = fh.read()
 

--- a/spudtr/__init__.py
+++ b/spudtr/__init__.py
@@ -73,6 +73,8 @@ def get_demo_df(filename, url=DATA_URL):
     # shortcut if previously downloaded
     if (DATA_DIR / filename).exists():
         return pd.read_feather(DATA_DIR / filename)
+    else:
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
 
     # otherwise download
     print(f"downloading ./spudtr/data/{filename} from {url} ... please wait")

--- a/spudtr/__init__.py
+++ b/spudtr/__init__.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import re
 
 # single source the python package version with a bit of error checking
-__version__ = "0.0.10.dev1"
+__version__ = "0.0.10.dev2"
 
 DATA_DIR = Path(__file__).parents[0] / "data"
 RESOURCES_DIR = Path(__file__).parents[0] / "resources"

--- a/spudtr/fake_epochs_data.py
+++ b/spudtr/fake_epochs_data.py
@@ -6,7 +6,7 @@ from patsy import balanced, demo_data
 
 
 def _generate(
-    n_epochs, n_samples, n_categories, n_channels, time=None, epoch_id=None, seed=None,
+    n_epochs, n_samples, n_categories, n_channels, time=None, epoch_id=None, seed=None
 ):
     """Return Pandas DataFrame with fake EEG data, and a list of channels."""
 
@@ -59,7 +59,7 @@ def _get_df(n_a=2, n_b=3, n_epochs=4, n_streams=3):
     data = np.arange(n_obs * n_streams).reshape(n_streams, n_obs).T
 
     df = pd.concat(
-        [pd.DataFrame(arry) for arry in [epoch_id, time, factors, data]], axis=1,
+        [pd.DataFrame(arry) for arry in [epoch_id, time, factors, data]], axis=1
     )
     df.columns = ["epoch_id", "time", "a", "b", "x", "y", "z"]
     return df

--- a/spudtr/mneutils.py
+++ b/spudtr/mneutils.py
@@ -155,7 +155,7 @@ def categories2eventid(epochs_df, categories, epoch_id, time, time_stamp):
 
     # mne array: n-events x 3
     mne_events = np.stack(
-        [events_df["epoch_id"].to_numpy(), np.zeros(len(events_df)), dm_col_code,],
+        [events_df["epoch_id"].to_numpy(), np.zeros(len(events_df)), dm_col_code],
         axis=1,
     ).astype("int")
     # pdb.set_trace()
@@ -236,7 +236,7 @@ def spudtr_to_mne_epochs(
         epoch1 = epochs_df[montage.ch_names][epochs_df.epoch_id == epoch_i].to_numpy()
         epochs_data.append(epoch1.T)
     epochs = mne.EpochsArray(
-        epochs_data, info=info, tmin=tmin, events=mne_events, event_id=mne_event_ids,
+        epochs_data, info=info, tmin=tmin, events=mne_events, event_id=mne_event_ids
     )
 
     return epochs

--- a/tests/test_epf.py
+++ b/tests/test_epf.py
@@ -1,4 +1,5 @@
-import pytest
+import numpy as np
+import pandas as pd
 
 # local HDF5 files to be deprecated in v0.0.11 with _hdf_read_epochs
 from spudtr import DATA_DIR  # , P3_F, P5_F, WR_F
@@ -7,11 +8,9 @@ from spudtr import DATA_DIR  # , P3_F, P5_F, WR_F
 from spudtr import get_demo_df, WR_100_FEATHER, P5_1500_FEATHER
 from spudtr import epf
 import spudtr.fake_epochs_data as fake_data
-
 from spudtr.epf import EPOCH_ID, TIME
 
-import numpy as np
-import pandas as pd
+import pytest
 
 # ------------------------------------------------------------
 # test epochs Zenodo https://doi.org/10.5281/zenodo.3968485

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -26,7 +26,7 @@ xfve = pytest.mark.xfail(strict=True, reason=ValueError)
 )
 def test_check_filter_params_obligatory(_ftype, _cutoff, _srate, _allow_defaults):
     filt_params = filters.check_filter_params(
-        ftype=_ftype, cutoff_hz=_cutoff, sfreq=_srate, allow_defaults=_allow_defaults,
+        ftype=_ftype, cutoff_hz=_cutoff, sfreq=_srate, allow_defaults=_allow_defaults
     )
 
 
@@ -166,7 +166,7 @@ def test_mfreqz():
         window=window,
     )
     _ = filters._mfreqz(
-        b=taps2, a=1, cutoff_hz=cutoff_hz, sfreq=sfreq, width_hz=width_hz,
+        b=taps2, a=1, cutoff_hz=cutoff_hz, sfreq=sfreq, width_hz=width_hz
     )
 
 
@@ -305,12 +305,7 @@ def test__trans_bwidth_ripple2(_ft, _cthz, _win, _ripdb):
 
 @pytest.mark.parametrize(
     "_ftype,_cutoff_hz",
-    [
-        ["lowpass", 20],
-        ["highpass", 20],
-        ["bandpass", [22, 40]],
-        ["bandstop", [18, 35]],
-    ],
+    [["lowpass", 20], ["highpass", 20], ["bandpass", [22, 40]], ["bandstop", [18, 35]]],
 )
 def test_filters_effect(_ftype, _cutoff_hz):
 

--- a/tests/test_mneutils.py
+++ b/tests/test_mneutils.py
@@ -68,13 +68,9 @@ def test_spudtr_to_mne_epochs():
     )
 
     epochs = mneutils.spudtr_to_mne_epochs(
-        epochs_df, **epoch_params, mne_events=mne_events, mne_event_ids=mne_event_ids,
+        epochs_df, **epoch_params, mne_events=mne_events, mne_event_ids=mne_event_ids
     )
-    assert epochs.event_id == {
-        "stim[cal]": 1,
-        "stim[standard]": 2,
-        "stim[target]": 3,
-    }
+    assert epochs.event_id == {"stim[cal]": 1, "stim[standard]": 2, "stim[target]": 3}
     assert epochs.ch_names == epoch_params["eeg_streams"]
 
     # 3. fail with event_id but no events
@@ -103,11 +99,7 @@ def test_categories2eventid():
 
     event_id_1_head = np.array([[0, 0, 3], [1, 0, 3], [2, 0, 3], [3, 0, 3], [4, 0, 3]])
 
-    assert mne_event_id == {
-        "stim[cal]": 1,
-        "stim[standard]": 2,
-        "stim[target]": 3,
-    }
+    assert mne_event_id == {"stim[cal]": 1, "stim[standard]": 2, "stim[target]": 3}
     assert np.array_equal(event_id_1_head, mne_events[0:5])
 
     # gold standard


### PR DESCRIPTION
* Switched ci/conda_upload.sh to upload M.N.P and M.N.P.devX to pre-release from dev branch instead of master. 
* Added travis build matrix to `conda python=$PYV build` to build, pytest, anaconda upload spudtr for Python 3.6, 3.7, 38, default.
* Deploy stage guarded to trigger docs and PyPI on python 3.8 only, conda still uploads on all versions.
* Single-source spudtr version with jinja in conda/meta.yaml