### PR TITLE
update CI to deploy pre-release docs on kutaslab.github.io

### DIFF
--- a/.github/workflows/spudtr_cid.yml
+++ b/.github/workflows/spudtr_cid.yml
@@ -62,12 +62,7 @@ on:
 env:
   PACKAGE_NAME: spudtr
   DEPLOY_PY_VER: 3.8  # only this job deploys codecov, docs, sdist
-  GH_USER_NAME: robo_kutaslab
 
-  GH_PAGES_BRANCH: gh-pages
-  # alternate repo for dev version docs
-  GH_PAGES_DEV_REPOSITORY: kutaslab/spudtr-dev-docs
-  GH_PAGES_DEV_BRANCH: gh-pages-dev
 
 defaults:
   run:
@@ -224,16 +219,31 @@ jobs:
         run: conda install -q codecov && codecov
 
       - name: deploy sphinx docs to gh-pages
+        # switch docs deployment repo/branch on deploy type
+
         #if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && (env.DEPLOY_TYPE == 'main' || env.DEPLOY_TYPE == 'pre-release') }}
         if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}
+        env:
+          # machine user account
+          GH_USER_NAME: robo-kutaslab
+          GH_USER_EMAIL: robo.kutaslab@gmail.com
+          API_GITHUB_TOKEN: ${{ secrets.API_GITHUB_TOKEN }}
+
+          # vM.N.P tagged release docs go here in $GITHUB_REPOSITORY
+          GH_PAGES_BRANCH: gh-pages
+
+          # actions on dev branch send docs to this separate repo
+          GH_PAGES_DEV_REPOSITORY: kutaslab/spudtr-dev-docs
+          GH_PAGES_DEV_BRANCH: gh-pages-dev
+
         run: |
           # set docs version repo/branch
           if [[ env.DEPLOY_TYPE == 'main' ]]; then \
-            gh-pages-repo=$GITHUB_REPOSITORY; \
-            gh-pages-branch=$GH_PAGES_BRANCH; \
+            DOCS_REPO="$GITHUB_REPOSITORY"; \
+            DOCS_BRANCH="$GH_PAGES_BRANCH"; \
           fi
-          gh-pages-repo=$GH_PAGES_DEV_REPOSITORY
-          gh-pages-branch=$GH_PAGES_DEV_BRANCH
+          DOCS_REPO="$GH_PAGES_DEV_REPOSITORY"
+          DOCS_BRANCH="$GH_PAGES_DEV_BRANCH"
 
           cd $GITHUB_WORKSPACE/docs/build/html  # wherever sphinx writes the html, repo specific
           git init 
@@ -241,17 +251,16 @@ jobs:
           # git config user.email "${user_name}@the.cloud.org"
           # git config user.name "$user_name"
           # git remote add origin "https://${user_name}:${{ secrets.github_token }}@github.com/${GITHUB_REPOSITORY}"
-          user_name=$GH_USER_NAME
-          git config user.email "robo.kutaslab@gmail.com"
-          git config user.name "$GH_USER_NAME
-          git remote add origin "https://$API_TOKEN_GITHUB@github.com/$GH_USER_NAME/$gh-pages-repo"
 
-          git checkout --orphan $gh-pages-branch
+          git config user.name "$GH_USER_NAME"
+          git config user.email "$GH_USER_EMAIL"
+          git remote add origin "https://$API_GITHUB_TOKEN@github.com/${DOCS_REPO}"
+
+          git checkout --orphan "$DOCS_BRANCH"
           git add -A
           git commit -a -m "deploy type $DEPLOY_TYPE python $DEPLOY_PY_VER"
           #git push -u origin gh-pages --force
-          git push -u origin $gh-pages-branch --force
-          
+          git push -u origin "$DOCS_BRANCH" --force
 
       - name: deploy python package M.N.P.devX to test.pypi.org
         if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && env.DEPLOY_TYPE == 'pre-release' }}

--- a/.github/workflows/spudtr_cid.yml
+++ b/.github/workflows/spudtr_cid.yml
@@ -63,7 +63,6 @@ env:
   PACKAGE_NAME: spudtr
   DEPLOY_PY_VER: 3.8  # only this job deploys codecov, docs, sdist
 
-
 defaults:
   run:
     # login shell to source the conda hook in .bash_profile
@@ -220,14 +219,13 @@ jobs:
 
       - name: deploy sphinx docs to gh-pages
         # switch docs deployment repo/branch on deploy type
-
-        #if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && (env.DEPLOY_TYPE == 'main' || env.DEPLOY_TYPE == 'pre-release') }}
-        if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}
+        if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && (env.DEPLOY_TYPE == 'main' || env.DEPLOY_TYPE == 'pre-release') }}
+        # if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}  # testing only
         env:
-          # machine user account
+          # machine user account PAT
           GH_USER_NAME: robo-kutaslab
           GH_USER_EMAIL: robo.kutaslab@gmail.com
-          API_GITHUB_TOKEN: ${{ secrets.API_GITHUB_TOKEN }}
+          GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
 
           # vM.N.P tagged release docs go here in $GITHUB_REPOSITORY
           GH_PAGES_BRANCH: gh-pages
@@ -238,28 +236,27 @@ jobs:
 
         run: |
           # set docs version repo/branch
-          if [[ env.DEPLOY_TYPE == 'main' ]]; then \
+          if [[ env.DEPLOY_TYPE == main ]]; then \
             DOCS_REPO="$GITHUB_REPOSITORY"; \
             DOCS_BRANCH="$GH_PAGES_BRANCH"; \
           fi
-          DOCS_REPO="$GH_PAGES_DEV_REPOSITORY"
-          DOCS_BRANCH="$GH_PAGES_DEV_BRANCH"
 
-          cd $GITHUB_WORKSPACE/docs/build/html  # wherever sphinx writes the html, repo specific
-          git init 
-          # user_name="docs_${GITHUB_EVENT_NAME}_bot"
-          # git config user.email "${user_name}@the.cloud.org"
-          # git config user.name "$user_name"
-          # git remote add origin "https://${user_name}:${{ secrets.github_token }}@github.com/${GITHUB_REPOSITORY}"
+          if [[ env.DEPLOY_TYPE == pre-release ]]; then \
+            DOCS_REPO="$GH_PAGES_DEV_REPOSITORY"; \
+            DOCS_BRANCH="$GH_PAGES_DEV_BRANCH"; \
+          fi
+
+          # wherever sphinx wrote the html, repo specific
+          cd $GITHUB_WORKSPACE/docs/build/html
+          git init
 
           git config user.name "$GH_USER_NAME"
           git config user.email "$GH_USER_EMAIL"
-          git remote add origin "https://$API_GITHUB_TOKEN@github.com/${DOCS_REPO}"
+          git remote add origin "https://$GH_PAGES_TOKEN@github.com/${DOCS_REPO}"
 
           git checkout --orphan "$DOCS_BRANCH"
           git add -A
           git commit -a -m "deploy type $DEPLOY_TYPE python $DEPLOY_PY_VER"
-          #git push -u origin gh-pages --force
           git push -u origin "$DOCS_BRANCH" --force
 
       - name: deploy python package M.N.P.devX to test.pypi.org

--- a/.github/workflows/spudtr_cid.yml
+++ b/.github/workflows/spudtr_cid.yml
@@ -62,6 +62,12 @@ on:
 env:
   PACKAGE_NAME: spudtr
   DEPLOY_PY_VER: 3.8  # only this job deploys codecov, docs, sdist
+  GH_USER_NAME: robo_kutaslab
+
+  GH_PAGES_BRANCH: gh-pages
+  # alternate repo for dev version docs
+  GH_PAGES_DEV_REPOSITORY: kutaslab/spudtr-dev-docs
+  GH_PAGES_DEV_BRANCH: gh-pages-dev
 
 defaults:
   run:
@@ -218,18 +224,34 @@ jobs:
         run: conda install -q codecov && codecov
 
       - name: deploy sphinx docs to gh-pages
-        if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && env.DEPLOY_TYPE == 'main' }}
+        #if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && (env.DEPLOY_TYPE == 'main' || env.DEPLOY_TYPE == 'pre-release') }}
+        if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}
         run: |
+          # set docs version repo/branch
+          if [[ env.DEPLOY_TYPE == 'main' ]]; then \
+            gh-pages-repo=$GITHUB_REPOSITORY; \
+            gh-pages-branch=$GH_PAGES_BRANCH; \
+          fi
+          gh-pages-repo=$GH_PAGES_DEV_REPOSITORY
+          gh-pages-branch=$GH_PAGES_DEV_BRANCH
+
           cd $GITHUB_WORKSPACE/docs/build/html  # wherever sphinx writes the html, repo specific
           git init 
-          user_name="docs_${GITHUB_EVENT_NAME}_bot"
-          git config user.email "${user_name}@the.cloud.org"
-          git config user.name "$user_name"
-          git remote add origin "https://${user_name}:${{ secrets.github_token }}@github.com/${GITHUB_REPOSITORY}"
-          git checkout --orphan gh-pages
+          # user_name="docs_${GITHUB_EVENT_NAME}_bot"
+          # git config user.email "${user_name}@the.cloud.org"
+          # git config user.name "$user_name"
+          # git remote add origin "https://${user_name}:${{ secrets.github_token }}@github.com/${GITHUB_REPOSITORY}"
+          user_name=$GH_USER_NAME
+          git config user.email "robo.kutaslab@gmail.com"
+          git config user.name "$GH_USER_NAME
+          git remote add origin "https://$API_TOKEN_GITHUB@github.com/$GH_USER_NAME/$gh-pages-repo"
+
+          git checkout --orphan $gh-pages-branch
           git add -A
           git commit -a -m "deploy type $DEPLOY_TYPE python $DEPLOY_PY_VER"
-          git push -u origin gh-pages --force
+          #git push -u origin gh-pages --force
+          git push -u origin $gh-pages-branch --force
+          
 
       - name: deploy python package M.N.P.devX to test.pypi.org
         if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && env.DEPLOY_TYPE == 'pre-release' }}

--- a/spudtr/__init__.py
+++ b/spudtr/__init__.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import re
 
 # single source the python package version
-__version__ = "0.0.15"
+__version__ = "0.0.16.dev0"
 
 DATA_DIR = Path(__file__).parents[0] / "data"
 RESOURCES_DIR = Path(__file__).parents[0] / "resources"


### PR DESCRIPTION
Until now only the stable release docs were available.

This update now has pre-release deployments on dev branch that upload conda packages also post the corresponding just-built sphinx docs on a secondary repo kutaslab/spudtr-dev-docs where they display on kutaslab.github.io/spudtr-dev-docs