### PR TITLE
update actions to deploy pre-release docs

### DIFF
--- a/.github/workflows/spudtr_cid.yml
+++ b/.github/workflows/spudtr_cid.yml
@@ -74,7 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        py_ver: [3.6, 3.7, 3.8]
+        #py_ver: [3.6, 3.7, 3.8]  # production
+        py_ver: [3.8]  # testing
 
     env:
       PY_VER: ${{ matrix.py_ver }}
@@ -236,27 +237,36 @@ jobs:
 
         run: |
           # set docs version repo/branch
-          if [[ env.DEPLOY_TYPE == main ]]; then \
-            DOCS_REPO="$GITHUB_REPOSITORY"; \
-            DOCS_BRANCH="$GH_PAGES_BRANCH"; \
+          if [[ ${{ env.DEPLOY_TYPE }} == main ]]; then \
+            DOCS_REPO=$GITHUB_REPOSITORY; \
+            DOCS_BRANCH=$GH_PAGES_BRANCH; \
           fi
 
-          if [[ env.DEPLOY_TYPE == pre-release ]]; then \
-            DOCS_REPO="$GH_PAGES_DEV_REPOSITORY"; \
-            DOCS_BRANCH="$GH_PAGES_DEV_BRANCH"; \
+          if [[ ${{ env.DEPLOY_TYPE }} == pre-release ]]; then \
+            DOCS_REPO=$GH_PAGES_DEV_REPOSITORY; \
+            DOCS_BRANCH=$GH_PAGES_DEV_BRANCH; \
           fi
+
+          if [[ ${{ env.DEPLOY_TYPE }} == no-deploy ]]; then \
+            DOCS_REPO=$GH_PAGES_DEV_REPOSITORY; \
+            DOCS_BRANCH=$GH_PAGES_DEV_BRANCH; \
+          fi
+
+          echo "deploy type ${{ env.DEPLOY_TYPE }}: sphinx docs to $DOCS_REPO $DOCS_BRANCH"
 
           # wherever sphinx wrote the html, repo specific
+          git config --global user.name $GH_USER_NAME
+          git config --global user.email $GH_USER_EMAIL
+          git config --global init.defaultBranch main
+
           cd $GITHUB_WORKSPACE/docs/build/html
           git init
 
-          git config user.name "$GH_USER_NAME"
-          git config user.email "$GH_USER_EMAIL"
           git remote add origin "https://$GH_PAGES_TOKEN@github.com/${DOCS_REPO}"
 
           git checkout --orphan "$DOCS_BRANCH"
           git add -A
-          git commit -a -m "deploy type $DEPLOY_TYPE python $DEPLOY_PY_VER"
+          git commit -a -m "deploy type ${DEPLOY_TYPE} python ${DEPLOY_PY_VER}"
           git push -u origin "$DOCS_BRANCH" --force
 
       - name: deploy python package M.N.P.devX to test.pypi.org

--- a/.github/workflows/spudtr_cid.yml
+++ b/.github/workflows/spudtr_cid.yml
@@ -99,6 +99,7 @@ jobs:
           bash miniconda.sh -b -p $HOME/miniconda
           conda shell.bash hook >> ~/.bash_profile  # instead of conda init bash
           mkdir -p $CONDA_BLD_PATH && rm miniconda.sh
+          hash
           source ~/.bash_profile && conda_activate
           hash -r
           conda config --set always_yes yes --set changeps1 no
@@ -220,8 +221,8 @@ jobs:
 
       - name: deploy sphinx docs to gh-pages
         # switch docs deployment repo/branch on deploy type
-        if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && (env.DEPLOY_TYPE == 'main' || env.DEPLOY_TYPE == 'pre-release') }}
-        # if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}  # testing only
+        # if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && (env.DEPLOY_TYPE == 'main' || env.DEPLOY_TYPE == 'pre-release') }}
+        if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}  # testing only
         env:
           # machine user account PAT
           GH_USER_NAME: robo-kutaslab

--- a/.github/workflows/spudtr_cid.yml
+++ b/.github/workflows/spudtr_cid.yml
@@ -97,11 +97,10 @@ jobs:
           echo "GIT_ABBREV_COMMIT=_g${GITHUB_SHA:0:8}" >> $GITHUB_ENV
           wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
           bash miniconda.sh -b -p $HOME/miniconda
+          hash -r
           conda shell.bash hook >> ~/.bash_profile  # instead of conda init bash
           mkdir -p $CONDA_BLD_PATH && rm miniconda.sh
-          hash
           source ~/.bash_profile && conda_activate
-          hash -r
           conda config --set always_yes yes --set changeps1 no
           conda config --set bld_path $CONDA_BLD_PATH
           conda install -q conda-build conda-verify anaconda twine
@@ -248,7 +247,7 @@ jobs:
             DOCS_BRANCH=$GH_PAGES_DEV_BRANCH; \
           fi
 
-          if [[ ${{ env.DEPLOY_TYPE }} == no-deploy ]]; then \
+          if [[ ${{ env.DEPLOY_TYPE }} == no_deploy ]]; then \
             DOCS_REPO=$GH_PAGES_DEV_REPOSITORY; \
             DOCS_BRANCH=$GH_PAGES_DEV_BRANCH; \
           fi
@@ -265,10 +264,10 @@ jobs:
 
           git remote add origin "https://$GH_PAGES_TOKEN@github.com/${DOCS_REPO}"
 
-          git checkout --orphan "$DOCS_BRANCH"
+          git checkout --orphan $DOCS_BRANCH
           git add -A
-          git commit -a -m "deploy type ${DEPLOY_TYPE} python ${DEPLOY_PY_VER}"
-          git push -u origin "$DOCS_BRANCH" --force
+          git commit -a -m "deploy type $DEPLOY_TYPE python $DEPLOY_PY_VER"
+          git push -u origin $DOCS_BRANCH --force
 
       - name: deploy python package M.N.P.devX to test.pypi.org
         if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && env.DEPLOY_TYPE == 'pre-release' }}

--- a/.github/workflows/spudtr_cid.yml
+++ b/.github/workflows/spudtr_cid.yml
@@ -74,8 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        #py_ver: [3.6, 3.7, 3.8]  # production
-        py_ver: [3.8]  # testing
+        py_ver: [3.6, 3.7, 3.8]  # production
 
     env:
       PY_VER: ${{ matrix.py_ver }}

--- a/.github/workflows/spudtr_cid.yml
+++ b/.github/workflows/spudtr_cid.yml
@@ -220,8 +220,8 @@ jobs:
 
       - name: deploy sphinx docs to gh-pages
         # switch docs deployment repo/branch on deploy type
-        # if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && (env.DEPLOY_TYPE == 'main' || env.DEPLOY_TYPE == 'pre-release') }}
-        if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}  # testing only
+        if: ${{ matrix.py_ver == env.DEPLOY_PY_VER && (env.DEPLOY_TYPE == 'main' || env.DEPLOY_TYPE == 'pre-release') }}
+        # if: ${{ matrix.py_ver == env.DEPLOY_PY_VER }}  # testing only
         env:
           # machine user account PAT
           GH_USER_NAME: robo-kutaslab
@@ -247,23 +247,17 @@ jobs:
             DOCS_BRANCH=$GH_PAGES_DEV_BRANCH; \
           fi
 
-          if [[ ${{ env.DEPLOY_TYPE }} == no_deploy ]]; then \
-            DOCS_REPO=$GH_PAGES_DEV_REPOSITORY; \
-            DOCS_BRANCH=$GH_PAGES_DEV_BRANCH; \
-          fi
-
           echo "deploy type ${{ env.DEPLOY_TYPE }}: sphinx docs to $DOCS_REPO $DOCS_BRANCH"
 
-          # wherever sphinx wrote the html, repo specific
           git config --global user.name $GH_USER_NAME
           git config --global user.email $GH_USER_EMAIL
           git config --global init.defaultBranch main
 
+          # wherever sphinx wrote the html, repo specific
           cd $GITHUB_WORKSPACE/docs/build/html
           git init
 
           git remote add origin "https://$GH_PAGES_TOKEN@github.com/${DOCS_REPO}"
-
           git checkout --orphan $DOCS_BRANCH
           git add -A
           git commit -a -m "deploy type $DEPLOY_TYPE python $DEPLOY_PY_VER"

--- a/.github/workflows/spudtr_cid.yml
+++ b/.github/workflows/spudtr_cid.yml
@@ -246,7 +246,7 @@ jobs:
             DOCS_BRANCH=$GH_PAGES_DEV_BRANCH; \
           fi
 
-          echo "deploy type ${{ env.DEPLOY_TYPE }}: sphinx docs to $DOCS_REPO $DOCS_BRANCH"
+          echo "deploy type ${{ env.DEPLOY_TYPE }}: sphinx docs on $DOCS_REPO/$DOCS_BRANCH"
 
           git config --global user.name $GH_USER_NAME
           git config --global user.email $GH_USER_EMAIL

--- a/spudtr/__init__.py
+++ b/spudtr/__init__.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import re
 
 # single source the python package version
-__version__ = "0.0.16.dev0"
+__version__ = "0.0.16"
 
 DATA_DIR = Path(__file__).parents[0] / "data"
 RESOURCES_DIR = Path(__file__).parents[0] / "resources"


### PR DESCRIPTION
The action on dev branch that uploads the conda M.N.P.devX package to anaconda.org kutaslab/label/pre-release now pushes the fresh built docs to the gh-pages-dev branch of the sibling github repo kutaslab/spudtr-dev-docs where they are available on kutaslab.github.io/spudtr-dev-docs.